### PR TITLE
Updated dendrogram parameter behavior to only modify plotting behavior

### DIFF
--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -173,14 +173,12 @@ d3heatmap <- function(x,
   ##=======================
   dendrogram <- match.arg(dendrogram)
   
-  # Use dendrogram argument to set defaults for Rowv/Colv
-  if (missing(Rowv)) {
-    Rowv <- dendrogram %in% c("both", "row")
-  }
-  if (missing(Colv)) {
-    Colv <- dendrogram %in% c("both", "column")
-  }
-
+  if ( is.null(Rowv) || is.na(Rowv) )
+    Rowv <- FALSE
+  if ( is.null(Colv) || is.na(Colv) )
+    Colv <- FALSE
+  else if( all(Colv=="Rowv") )
+    Colv <- Rowv
 
   if (isTRUE(Rowv)) {
     Rowv <- rowMeans(x, na.rm = na.rm)


### PR DESCRIPTION
In `heatmap.2()` the `dendrogram` parameter only affects whether or not the dendrograms are _drawn_, not how the columns and rows are actually ordered.

I removed the logic that uses `dendrogram` to determine how `Rowv` and `Colv` should behave, and instead adopted the same behavior as `heatmap.2`.
